### PR TITLE
Fix capitalization in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
-$api = new Harvest\HarvestApi();
+$api = new Harvest\HarvestAPI();
 $api->setUser('your@email.com');
 $api->setPassword('password');
 $api->setAccount('account');


### PR DESCRIPTION
Changed HarvestApi to HarvestAPI. The former form was incorrect and
threw errors when running the example.
